### PR TITLE
Django Part 4: Django admin site

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Checklist tự review pull trước khi ready để trainer review
+- [ ] Sử dụng thụt lề 2 spaces/4 spaces đồng nhất ở tất cả các files (setting lại vscode /sublime text/ ... nếu chưa cài đặt)
+- [ ] Cuối mỗi file kiểm tra có end line (khi đẩy lên git xem file change không bị lỗi tròn đỏ ở cuối file)
+- [ ] Mỗi dòng nếu quá dài, cần xuống dòng (maximum: 80 kí tự mỗi dòng, setting trong IDE)
+- [ ] gitignore các file chứa thông tin nhạy cảm (VD: .env, ..), file .pyc (python cache), ...
+- [ ] Tham khảo Python coding convention https://peps.python.org/pep-0008/
+- [ ] Kiểm tra mỗi pull request chỉ 1 commit, nếu nhiều hơn 1 commit thì hãy gộp commit thành 1 rồi đẩy lại lên git
+- [ ] Install [PEP8](https://pypi.org/project/pep8/) ở local để check và fix các lỗi liên quan đến syntax, coding convention. Khi gửi thì chụp ảnh PASS đính kèm trong pull
+- [ ] Nếu làm việc nhóm trong project thì mỗi pull cần **ít nhất 1 APPROVED** từ thành viên trong nhóm
+
+## Related Tickets
+- ticket redmine link
+
+## WHAT (optional)
+- Change number items `completed/total` in admin page.
+
+## HOW
+- I edit js file, inject not_vary_normal items in calculate function.
+
+## WHY (optional)
+- Because in previous version - number just depends on `normal` items. But in new version, we have `state` and `confirm_state` depends on both `normal` + `not_normal` items.
+
+## Evidence (Screenshot or Video)
+
+
+## Notes (Kiến thức tìm hiểu thêm)

--- a/catalog/admin.py
+++ b/catalog/admin.py
@@ -1,3 +1,60 @@
-from __future__ import annotations
-
 from django.contrib import admin
+from .models import Author, Genre, Book, BookInstance, Language
+
+
+@admin.register(Genre)
+class GenreAdmin(admin.ModelAdmin):
+    list_display = ('name',)
+    search_fields = ('name',)
+    ordering = ('name',)
+
+
+@admin.register(Language)
+class LanguageAdmin(admin.ModelAdmin):
+    list_display = ('name',)
+    search_fields = ('name',)
+    ordering = ('name',)
+
+
+class BooksInstanceInline(admin.TabularInline):
+    model = BookInstance
+    extra = 0
+
+
+@admin.register(Author)
+class AuthorAdmin(admin.ModelAdmin):
+    list_display = (
+        'last_name',
+        'first_name',
+        'date_of_birth',
+        'date_of_death')
+    fields = ['first_name', 'last_name', ('date_of_birth', 'date_of_death')]
+    ordering = ('last_name', 'first_name')
+    search_fields = ('first_name', 'last_name')
+
+
+@admin.register(Book)
+class BookAdmin(admin.ModelAdmin):
+    list_display = ('title', 'author', 'display_genre')
+    inlines = [BooksInstanceInline]
+    ordering = ('title',)
+    search_fields = ('title', 'author__last_name')
+
+    def display_genre(self, obj):
+        return ', '.join(genre.name for genre in obj.genre.all()[:3])
+    display_genre.short_description = 'Genre'
+
+
+@admin.register(BookInstance)
+class BookInstanceAdmin(admin.ModelAdmin):
+    list_display = ('book', 'status', 'due_back', 'id')
+    list_filter = ('status', 'due_back')
+    ordering = ('due_back',)
+    fieldsets = (
+        (None, {
+            'fields': ('book', 'imprint', 'id')
+        }),
+        ('Availability', {
+            'fields': ('status', 'due_back')
+        }),
+    )


### PR DESCRIPTION
### WHAT
Cấu hình Django admin cho các model Author, Book, BookInstance

### HOW
- Sử dụng @admin.register để đăng ký model
- Thêm list_display và fieldsets cho BookInstance
- Tạo hàm display_genre hiển thị tên thể loại trong BookAdmin
- Dùng inline để hiển thị BookInstance trong Book

### Evidence (Screenshot or Video)
<img width="1919" height="904" alt="image" src="https://github.com/user-attachments/assets/cdfa8ac1-e095-4dcb-a2a3-3d9a732c8f84" />
<img width="735" height="145" alt="image" src="https://github.com/user-attachments/assets/998035de-4fea-4ff2-a211-d72f974ed883" />

### Notes 
- PEP8 và pycodestyle để tuân thủ coding convention Python.